### PR TITLE
Shell style shellcheck - controller bash->sh may avoid error

### DIFF
--- a/data/etc/Spotmarket-Switcher/controller.sh
+++ b/data/etc/Spotmarket-Switcher/controller.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 License=$(cat <<EOLICENSE
 MIT License


### PR DESCRIPTION
Cannot use the detection of the beginning of a line ("^") in shell variable substition, which shellcheck complains about.