### PR TITLE
Fixing errant grep behaviour - bad exit value when no match found

### DIFF
--- a/data/etc/Spotmarket-Switcher/service/run
+++ b/data/etc/Spotmarket-Switcher/service/run
@@ -33,7 +33,8 @@ code2='(crontab -l \| grep -Fxq \"0 * * * * /data/etc/Spotmarket-Switcher/contro
 # Count number of occurences of the code to be executed in the rc.local file
 count=0
 if [ -e "$rc_local_file" ]; then
-    count=$(grep -Fc "$code" "$rc_local_file")
+    # if grep finds no matching line the return code is != 0
+    count=$(grep -Fc "$code" "$rc_local_file" || echo 0)
 else
     echo "#!/bin/sh" > $rc_local_file
     chmod +x $rc_local_file


### PR DESCRIPTION
On a sidenote - this otherwise difficult problem was indeed identified in my attempts to work with that Venus OS docker image. One may argue that the effort already paid off. :)